### PR TITLE
Added Sequential layer for reduced boilerplate.

### DIFF
--- a/src/layer/builders.rs
+++ b/src/layer/builders.rs
@@ -1,4 +1,4 @@
-use super::{Conv2d, Dense, MaxPool2d};
+use super::{Conv2d, Dense, MaxPool2d, Sequential, SequentialEmpty, SequentialBase};
 use crate::{Conv2dArgs, Device, Into2d, Pool2dArgs};
 
 #[derive(Default, Clone)]
@@ -91,3 +91,27 @@ impl MaxPool2dBuilder {
         self.into()
     }
 }
+
+pub struct SequentialBuilder<S>(pub(super) S);
+
+impl Default for SequentialBuilder<SequentialEmpty> {
+    fn default() -> Self {
+        SequentialBuilder(SequentialEmpty{})
+    }
+}
+
+impl<S> SequentialBuilder<S> {
+    pub fn layer<N>(self, layer: N) -> SequentialBuilder<SequentialBase<S, N>> {
+        SequentialBuilder(SequentialBase { 
+            seq: self.0,
+            node: layer
+        })
+    }
+    pub fn build(self) -> Sequential<S> {
+        self.into()
+    }
+}
+
+
+
+


### PR DESCRIPTION
Addresses #21. Along with branches flatten_layer and forward_requires_layer, you could then do something like this:
```
fn lenet5(device: &Device) -> impl Forward<Ix4, OutputDim=Ix2> {
    Sequential::builder()
        .layer(
            Conv2d::builder()
                .device(&device)
                .inputs(1)
                .outputs(6)
                .kernel(5)
                .build();
        )
        .layer(Relu::default())
        .layer(
            MaxPool2d::builder()
                .args(
                    Pool2dArgs::default()
                        .kernel(2)
                        .strides(2)
                )
                .build()
        )
        .layer(
            Conv2d::builder()
                .device(&device)
                .inputs(6)
                .outputs(16)
                .kernel(5)
                .build()
            )
        )
        .layer(Relu::default())
        .layer(
            MaxPool2d::builder()
                .args(
                    Pool2dArgs::default()
                        .kernel(2)
                        .strides(2)
                )
                .build()
        )
        .layer(Flatten::default())
        .layer(
            Dense::builder()
                .device(&device)
                .inputs(256)
                .outputs(120)
                .build()
        )
        .layer(Relu::default())
        .layer(
            Dense::builder()
            .device(&device)
            .inputs(120)
            .outputs(84)
            .build()
        )
        .layer(Relu::default())
        .layer(
            Dense::builder()
                .device(&device)
                .inputs(84)
                .outputs(10)
                .bias()
                .build()
        )
        .build()
}
```